### PR TITLE
Adds contour 1.26.1 and 1.22.3 rocks

### DIFF
--- a/1.22.3/rockcraft.yaml
+++ b/1.22.3/rockcraft.yaml
@@ -1,0 +1,44 @@
+name: contour
+base: bare
+build-base: ubuntu@22.04
+license: Apache-2.0
+
+version: '1.22.3'
+summary: Contour is an open source Kubernetes ingress controller.
+description: |
+  Contour is an open source Kubernetes ingress controller that works by deploying
+  the Envoy proxy as a reverse proxy and load balancer.
+  Overview of Contour Trademarks: This software listing is packaged by Bitnami.
+  The respective trademarks mentioned in the offering are owned by the respective companies,
+  and use of them does not imply any affiliation or endorsement.
+platforms:
+  amd64:
+  arm64:
+
+
+services:
+  contour:
+    override: replace
+    summary: "contour service"
+    startup: enabled
+    command: "contour [ -h ]"
+    on-failure: shutdown
+
+entrypoint-service: contour
+
+
+parts:
+  contour:
+    plugin: nil
+    source: https://github.com/projectcontour/contour.git
+    source-type: git
+    source-tag: v${CRAFT_PROJECT_VERSION}
+    source-depth: 1
+    build-snaps:
+      - go/1.19/stable
+    build-environment:
+      - GOARCH: $CRAFT_ARCH_BUILD_FOR
+    override-build: |
+      make build
+      mkdir -p "${CRAFT_PART_INSTALL}/bin"
+      cp contour "${CRAFT_PART_INSTALL}/bin/"

--- a/1.26.1/rockcraft.yaml
+++ b/1.26.1/rockcraft.yaml
@@ -1,0 +1,44 @@
+name: contour
+base: bare
+build-base: ubuntu@22.04
+license: Apache-2.0
+
+version: '1.26.1'
+summary: Contour is an open source Kubernetes ingress controller.
+description: |
+  Contour is an open source Kubernetes ingress controller that works by deploying
+  the Envoy proxy as a reverse proxy and load balancer.
+  Overview of Contour Trademarks: This software listing is packaged by Bitnami.
+  The respective trademarks mentioned in the offering are owned by the respective companies,
+  and use of them does not imply any affiliation or endorsement.
+platforms:
+  amd64:
+  arm64:
+
+
+services:
+  contour:
+    override: replace
+    summary: "contour service"
+    startup: enabled
+    command: "contour [ -h ]"
+    on-failure: shutdown
+
+entrypoint-service: contour
+
+
+parts:
+  contour:
+    plugin: nil
+    source: https://github.com/projectcontour/contour.git
+    source-type: git
+    source-tag: v${CRAFT_PROJECT_VERSION}
+    source-depth: 1
+    build-snaps:
+      - go/1.20/stable
+    build-environment:
+      - GOARCH: $CRAFT_ARCH_BUILD_FOR
+    override-build: |
+      make build
+      mkdir -p "${CRAFT_PART_INSTALL}/bin"
+      cp contour "${CRAFT_PART_INSTALL}/bin/"

--- a/tests/integration/test_contour.py
+++ b/tests/integration/test_contour.py
@@ -10,7 +10,7 @@ import os
 from pathlib import Path
 
 from k8s_test_harness import harness
-from k8s_test_harness.util import exec_util, k8s_util
+from k8s_test_harness.util import env_util, exec_util, k8s_util
 
 pytest_plugins = ["k8s_test_harness.plugin"]
 
@@ -24,12 +24,12 @@ LOG = logging.getLogger(__name__)
 
 
 def test_integration_contour(module_instance: harness.Instance):
-    image_name_env_variable = "ROCK_CONTOUR"
-
-    image_uri = os.getenv(image_name_env_variable)
-    assert image_uri is not None, f"{image_name_env_variable} is not set"
+    contour_rock = env_util.get_build_meta_info_for_rock_version(
+        "contour", "1.28.2", "amd64"
+    )
 
     # This helm chart requires the registry to be separated from the image.
+    image_uri = contour_rock.image
     registry = "docker.io"
     parts = image_uri.split("/")
     if len(parts) > 1:

--- a/tests/sanity/test_rock.py
+++ b/tests/sanity/test_rock.py
@@ -2,16 +2,18 @@
 # Copyright 2024 Canonical, Ltd.
 # See LICENSE file for licensing details
 #
-import os
 
-from k8s_test_harness.util import docker_util
+import pytest
+from k8s_test_harness.util import docker_util, env_util
 
 
-def test_sanity():
-    image_variable = "ROCK_CONTOUR"
+@pytest.mark.parametrize("image_version", ("1.28.2", "1.26.1", "1.22.3"))
+def test_sanity(image_version):
+    rock = env_util.get_build_meta_info_for_rock_version(
+        "contour", image_version, "amd64"
+    )
+    image = rock.image
+
     entrypoint = "contour"
-    image = os.getenv(image_variable)
-    assert image is not None, f"${image_variable} is not set"
-
     process = docker_util.run_in_docker(image, [entrypoint, "--help"], False)
     assert "Contour Kubernetes ingress controller." in process.stderr

--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -44,6 +44,7 @@ commands =
 pass_env =
     TEST_*
     ROCK_*
+    BUILT_ROCKS_METADATA
 
 [testenv:integration]
 description = Run integration tests
@@ -60,6 +61,7 @@ commands =
 pass_env =
     TEST_*
     ROCK_*
+    BUILT_ROCKS_METADATA
 
 
 [flake8]


### PR DESCRIPTION
The mentioned rock versions do not include ``procps``, as it isn't included in the original project's Dockerfile (they're scratch-based images).

Depends-On: https://github.com/canonical/contour-rocks/pull/6