### PR TITLE
Cleanup 1.28.2 rock

### DIFF
--- a/1.28.2/rockcraft.yaml
+++ b/1.28.2/rockcraft.yaml
@@ -34,8 +34,6 @@ parts:
     source-type: git
     source-tag: v1.28.2
     source-depth: 1
-    stage-packages:
-      - procps
     build-snaps:
       - go/1.21/stable
     override-build: |

--- a/1.28.2/rockcraft.yaml
+++ b/1.28.2/rockcraft.yaml
@@ -6,10 +6,10 @@ license: Apache-2.0
 version: '1.28.2'
 summary: Contour is an open source Kubernetes ingress controller.
 description: |
-  Contour is an open source Kubernetes ingress controller that works by deploying 
+  Contour is an open source Kubernetes ingress controller that works by deploying
   the Envoy proxy as a reverse proxy and load balancer.
-  Overview of Contour Trademarks: This software listing is packaged by Bitnami. 
-  The respective trademarks mentioned in the offering are owned by the respective companies, 
+  Overview of Contour Trademarks: This software listing is packaged by Bitnami.
+  The respective trademarks mentioned in the offering are owned by the respective companies,
   and use of them does not imply any affiliation or endorsement.
 platforms:
   amd64:
@@ -37,7 +37,6 @@ parts:
     build-snaps:
       - go/1.21/stable
     override-build: |
-      make build 
+      make build
       mkdir -p "${CRAFT_PART_INSTALL}/bin/"
-      cp contour ${CRAFT_PART_INSTALL}/bin/contour
-
+      cp contour ${CRAFT_PART_INSTALL}/bin/

--- a/1.28.2/rockcraft.yaml
+++ b/1.28.2/rockcraft.yaml
@@ -38,5 +38,6 @@ parts:
       - go/1.21/stable
     override-build: |
       make build 
+      mkdir -p "${CRAFT_PART_INSTALL}/bin/"
       cp contour ${CRAFT_PART_INSTALL}/bin/contour
 


### PR DESCRIPTION
``procps`` isn't included in the original project's Dockerfile (they're scratch-based images). It is now removed.

Makes sure the ``${CRAFT_PART_INSTALL}/bin/`` destination directory exists before the copy.

Cleans up training whitespaces in ``rockcraft.yaml`` file.